### PR TITLE
Change hostname for RSS.com

### DIFF
--- a/src/hosts.json
+++ b/src/hosts.json
@@ -1122,7 +1122,7 @@
     {
         "pattern": "rss.com",
         "rss-pattern": ".rss.com",
-        "hostname": "RSS Podcasting",
+        "hostname": "RSS.com",
         "retailer": "1",
         "iab": "0",
         "abilities_stats": "1",


### PR DESCRIPTION
Change hostname for RSS.com (RSS.com is not only the domain but also the DBA of the company)