### PR TITLE
Added Afripods

### DIFF
--- a/src/hosts.json
+++ b/src/hosts.json
@@ -73,7 +73,7 @@
         "pattern": "afripods.com",
         "rss-pattern": "afripods.com",
         "hostname": "Afripods",
-        "retailer": "0",
+        "retailer": "1",
         "iab": "0",
         "abilities_stats": "1",
         "abilities_tracking": "0",

--- a/src/hosts.json
+++ b/src/hosts.json
@@ -70,6 +70,20 @@
         "pi-slug": "Acast"
     },
     {
+        "pattern": "afripods.com",
+        "rss-pattern": "afripods.com",
+        "hostname": "Afripods",
+        "retailer": "0",
+        "iab": "0",
+        "abilities_stats": "1",
+        "abilities_tracking": "0",
+        "abilities_dynamicaudio": "1",
+        "hosturl": "https:\/\/afripods.africa",
+        "hostprivacyurl": "https:\/\/afripods.africa\/privacy-policy",
+        "notes": "Dynamic Ad Insertion: Afripods have an IAB certified digital audio advertising partner (Adswizz) for providing ADI.",
+        "pi-slug": "Afripods"
+    },
+    {
         "pattern": "publicradio.org",
         "rss-pattern": ".publicradio.org",
         "hostname": "American Public Media",

--- a/src/hosts.json
+++ b/src/hosts.json
@@ -80,7 +80,7 @@
         "abilities_dynamicaudio": "1",
         "hosturl": "https:\/\/afripods.africa",
         "hostprivacyurl": "https:\/\/afripods.africa\/privacy-policy",
-        "notes": "Dynamic Ad Insertion: Afripods have an IAB certified digital audio advertising partner (Adswizz) for providing ADI.",
+        "notes": "Dynamic Ad Insertion: Afripods have an IAB certified digital audio advertising partner (Adswizz) for providing DAI.",
         "pi-slug": "Afripods"
     },
     {


### PR DESCRIPTION
Afripods is an innovative platform for podcasters, listeners, and advertisers, built to serve the podcasters in Africa.

Focused on the worlds fastest growing digital continent Africa, we aim to help spread great stories, insights, and entertainment. 

With Afripods, users from all over the world are able to listen to their favorite podcast, new voices and great stories produced by Africans, and people interested in Africa.
