### PR TITLE
Add CoHost podcasting as a new retail host

### DIFF
--- a/src/hosts.json
+++ b/src/hosts.json
@@ -2427,5 +2427,19 @@
       "hostprivacyurl": "https:\/\/www.spooler.fm\/privacy-policy.html",
       "notes": "",
       "pi-slug": ""
+    },
+    {
+      "pattern": "cohostpodcasting.com",
+      "rss-pattern": "cohostpodcasting.com",
+      "hostname": "CoHost",
+      "retailer": "1",
+      "iab": "0",
+      "abilities_stats": "1",
+      "abilities_tracking": "1",
+      "abilities_dynamicaudio": "0",
+      "hosturl": "https:\/\/www.cohostpodcasting.com\/",
+      "hostprivacyurl": "https:\/\/www.cohostpodcasting.com\/privacy-policy",
+      "notes": "",
+      "pi-slug": ""
     }
 ]


### PR DESCRIPTION
example feed: https://feeds.cohostpodcasting.com/NMv1gBpz
example enclosure: https://chrt.fm/track/9C8672/audio-delivery.cohostpodcasting.com/audio/e7695832-62a5-47e7-a7a6-0aa27d8d84ec/episodes/3ae4881e-c496-44e7-bf94-d01373e03d74/episode.mp3