### PR TITLE
Add host Global

### DIFF
--- a/src/hosts.json
+++ b/src/hosts.json
@@ -2457,17 +2457,17 @@
       "pi-slug": ""
     },
     {
-      "pattern": "api.spreaker.com",
+      "pattern": "spreaker.com",
       "rss-pattern": "podcast.global.com",
       "hostname": "Global",
       "retailer": "0",
-      "iab": "0",
+      "iab": "1",
       "abilities_stats": "1",
-      "abilities_tracking": "1",
+      "abilities_tracking": "0",
       "abilities_dynamicaudio": "1",
-      "hosturl": "https://global.com/",
+      "hosturl": "https:\/\/global.com\/dax\/audio\/podcast-publishers\/",
       "hostprivacyurl": "https://global.com/legal/privacy-policy",
-      "notes": "",
+      "notes": "Uses Spreaker as a whitelabelled CMS for their network of shows",
       "pi-slug": ""
     }
 ]

--- a/src/hosts.json
+++ b/src/hosts.json
@@ -2466,7 +2466,7 @@
       "abilities_tracking": "0",
       "abilities_dynamicaudio": "1",
       "hosturl": "https:\/\/global.com\/dax\/audio\/podcast-publishers\/",
-      "hostprivacyurl": "https://global.com/legal/privacy-policy",
+      "hostprivacyurl": "https:\/\/global.com\/legal\/privacy-policy",
       "notes": "Uses Spreaker as a whitelabelled CMS for their network of shows",
       "pi-slug": ""
     }

--- a/src/hosts.json
+++ b/src/hosts.json
@@ -2455,5 +2455,19 @@
       "hostprivacyurl": "https:\/\/podvine.com\/privacy-policy",
       "notes": "",
       "pi-slug": ""
+    },
+    {
+      "pattern": "api.spreaker.com",
+      "rss-pattern": "podcast.global.com",
+      "hostname": "Global",
+      "retailer": "0",
+      "iab": "0",
+      "abilities_stats": "1",
+      "abilities_tracking": "1",
+      "abilities_dynamicaudio": "1",
+      "hosturl": "https://global.com/",
+      "hostprivacyurl": "https://global.com/legal/privacy-policy",
+      "notes": "",
+      "pi-slug": ""
     }
 ]


### PR DESCRIPTION
Hi there 👋. I ran into an issue where I was checking for Global.com podcasts, but since they piggyback off of Spreaker for enclosures, I was getting a false positive. Here's an example feed:
https://podcast.global.com/show/4467866/episodes/feed

This additional pattern will match Spreaker API enclosure files and Global RSS feeds.

Let me know if you have any questions. Thanks!