### PR TITLE
Cleanup Libsyn entry, remove obsolete LibsynPro

### DIFF
--- a/src/hosts.json
+++ b/src/hosts.json
@@ -644,7 +644,7 @@
         "pi-slug": "Librivox"
     },
     {
-        "pattern": "traffic.libsyn.com",
+        "pattern": "libsyn.com",
         "rss-pattern": "libsyn.com",
         "hostname": "Libsyn",
         "retailer": "1",
@@ -652,23 +652,9 @@
         "abilities_stats": "1",
         "abilities_tracking": "0",
         "abilities_dynamicaudio": "1",
-        "hosturl": "https:\/\/www.libsyn.com\/",
-        "hostprivacyurl": "https:\/\/libsyn.com\/tos-policies\/legal\/",
-        "notes": "Dynamic ad insertion described as 'Ad stitching to...",
-        "pi-slug": "Libsyn"
-    },
-    {
-        "pattern": "traffic.libsyn.com",
-        "rss-pattern": "libsynpro.com",
-        "hostname": "LibsynPro",
-        "retailer": "0",
-        "iab": "1",
-        "abilities_stats": "1",
-        "abilities_tracking": "0",
-        "abilities_dynamicaudio": "1",
-        "hosturl": "https:\/\/libsynpro.com\/",
-        "hostprivacyurl": "https:\/\/libsynpro.com\/terms-of-service\/",
-        "notes": "Dynamic ad insertion described as 'Ad stitching tools' here: https:\/\/libsyn.com\/monetization\/",
+        "hosturl": "https:\/\/libsyn.com\/",
+        "hostprivacyurl": "https:\/\/libsyn.com\/tos-policies\/privacy-policy\/",
+        "notes": "Dynamic ad insertion via AdvertiseCast, described here: https:\/\/www.advertisecast.com\/podcast-ad-units",
         "pi-slug": "Libsyn"
     },
     {


### PR DESCRIPTION
Remove LibsynPro, as the rss pattern (and brand?) is now obsolete.  All of the podcasts examples promoted on https://libsyn.com/libsynpro-enterprise-podcasting/ have normal libsyn rss feed urls, or custom domains.

Also cleaned up the main Libsyn entry.
 - The media pattern needs to include `hwcdn.libsyn.com`, `content.libsyn.com`, as well as `traffic.libsyn.com`
 - Fix broken links to their current equivalents