### PR TITLE
Add Katapod to hosts.json

### DIFF
--- a/src/hosts.json
+++ b/src/hosts.json
@@ -588,6 +588,20 @@
         "pi-slug": "julephosting.de"
     },
     {
+        "pattern": "katapod.com",
+        "rss-pattern": "feeds.katapod.com",
+        "hostname": "Katapod",
+        "retailer": "1",
+        "iab": "0",
+        "abilities_stats": "1",
+        "abilities_tracking": "0",
+        "abilities_dynamicaudio": "1",
+        "hosturl": "https:\/\/www.katapod.com\/",
+        "hostprivacyurl": "https:\/\/www.katapod.com\/policy\/privacy-policy",
+        "notes": "Dynamic audio described in https:\/\/castos.com\/dynamic-ad-insertion-for-podcasts\/",
+        "pi-slug": "Katapod"
+    },
+    {
         "pattern": "media.adknit.com",
         "rss-pattern": "",
         "hostname": "knit",


### PR DESCRIPTION
I've added Katapod to the list. Additional `evidence of 'abilities'` will be added in the coming months as we open up our platform to the public.